### PR TITLE
Add support for live presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ pip install git+https://github.com/shadanan/codeanim
 The run command uses a custom keybinding. Please add this to your `keybindings.json` file in VS Code:
 
 ```json
-// Place your key bindings in this file to override the defaultsauto[]
 [
   {
     "key": "ctrl+shift+alt+cmd+enter",
@@ -64,6 +63,11 @@ To execute the CodeAnim commands in the Markdown file:
 ```shell
 codeanim codeanim-markdown-demo.md
 ```
+
+#### Flags
+
+- Set `-v` or `--verbose` to enable verbose mode. Commands will be printed out as they are executed.
+- Set `--live` to enable presentation mode. In this mode, a wait() will be injected after every codeanim fence.
 
 ### Usage of CodeAnim Library
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codeanim"
-version = "0.0.3"
+version = "0.0.4"
 authors = [{ name = "Shad Sharma", email = "shadanan@gmail.com" }]
 description = "A tool to animate VS Code"
 dependencies = ["pynput", "pyperclip"]

--- a/src/codeanim/__init__.py
+++ b/src/codeanim/__init__.py
@@ -13,6 +13,7 @@ from .core import (  # noqa: F401
     tap,
     write,
 )
+from .monitor import wait  # noqa: F401
 
 
 def main():
@@ -45,11 +46,16 @@ def main():
         default=os.environ.get("CODE_ANIM_END_DELAY"),
         help="The delay at the end of each animation command",
     )
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Insert wait after each codeanim block",
+    )
     args = parser.parse_args()
 
     set_delays(tap=args.tap_delay, end=args.end_delay)
 
-    expressions = markdown.parse(args.markdown, args.labels)
+    expressions = markdown.parse(args.markdown, args.labels, args.live)
     for expression in expressions:
         if args.verbose:
             print(expression)

--- a/src/codeanim/markdown.py
+++ b/src/codeanim/markdown.py
@@ -1,7 +1,7 @@
 import ast
 
 
-def parse(path: str, labels: list[str] | None) -> list[str]:
+def parse(path: str, labels: list[str] | None, live: bool) -> list[str]:
     with open(path) as f:
         lines = f.read().splitlines()
 
@@ -15,6 +15,8 @@ def parse(path: str, labels: list[str] | None) -> list[str]:
             is_codeanim = codeanim and (labels is None or label in labels)
             continue
         if line == "```":
+            if is_codeanim and live:
+                codeanim_lines.append("wait()")
             is_codeanim = False
             continue
         if is_codeanim:

--- a/src/codeanim/monitor.py
+++ b/src/codeanim/monitor.py
@@ -1,0 +1,34 @@
+from threading import Event
+
+from pynput.keyboard import Key, KeyCode, Listener
+
+
+class KeyMonitor:
+    def __init__(self):
+        self.press = Event()
+        self.released: Key | KeyCode | None = None
+
+    def handle_release(self, key: Key | KeyCode | None):
+        self.released = key
+        self.press.set()
+
+    def start(self):
+        self.listener = Listener(on_release=self.handle_release)
+        self.listener.start()
+
+    def stop(self):
+        self.listener.stop()
+
+    def wait(self, key: Key):
+        print(f"Press and release {key.name} to continue")
+        while key != self.released:
+            self.press.wait()
+            self.press.clear()
+
+
+monitor = KeyMonitor()
+monitor.start()
+
+
+def wait(key: Key = Key.shift):
+    monitor.wait(key)

--- a/tests/e2e.md
+++ b/tests/e2e.md
@@ -11,7 +11,11 @@ vscode.focus("scratch.py")
 
 # Insert print("Hello, World!") into scratch.py
 write('print("Hello, World!")\n')
+```
 
+If `codeanim` is executed with the `--live` command, a wait() will be inserted here.
+
+```python codeanim
 # Execute the script
 vscode.run()
 ```

--- a/tests/scratch.py
+++ b/tests/scratch.py
@@ -1,0 +1,1 @@
+print("Hello, World!")

--- a/tests/vscode.py
+++ b/tests/vscode.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
-from codeanim import vscode, write
+from codeanim import vscode, wait, write
 
 # Bring VS Code to the front
 vscode.activate()
+
+# Wait for shift to be pressed
+wait()
 
 # Resize VS Code to 800x600
 vscode.resize((0, 25), (800, 600))


### PR DESCRIPTION
This PR adds support for live presentation. Pass the `--live` flag, or add `wait()` commands to your CodeAnim script and the animation will pause and wait for the shift key to be pressed and released before continuing. Demo:

![codeanim-live](https://github.com/shadanan/codeanim/assets/361429/260f8aba-885b-4116-926f-4eb283a5a346)
