### PR TITLE
Remove pause arg from codeanim commands

### DIFF
--- a/src/codeanim/__init__.py
+++ b/src/codeanim/__init__.py
@@ -51,7 +51,7 @@ def main():
     )
     args = parser.parse_args()
 
-    delay.set(tap=args.tap_delay, end=args.end_delay)
+    delay.set(end=args.end_delay, tap=args.tap_delay)
 
     with KeyMonitor() as monitor:
         wait = monitor.wait  # noqa: F841

--- a/src/codeanim/chrome.py
+++ b/src/codeanim/chrome.py
@@ -18,7 +18,8 @@ def resize(position: tuple[int, int], size: tuple[int, int]):
 @core.codeanim
 def navigate(url: str):
     core.tap("l", modifiers=[Key.cmd])
-    core.write(url, pause=0)  # type: ignore
+    with core.delay(0):
+        core.write(url)
     core.tap(Key.enter)
 
 

--- a/src/codeanim/vscode.py
+++ b/src/codeanim/vscode.py
@@ -34,7 +34,8 @@ def palette(cmd: str):
 @core.codeanim
 def newline(line: int = 0, *, above: bool = False):
     if line > 0:
-        jump(line, pause=0)  # type: ignore
+        with core.delay(0):
+            jump(line)
         core.tap(Key.enter, modifiers=[Key.cmd, Key.shift])
     else:
         core.tap(Key.enter, modifiers=[Key.cmd, Key.shift] if above else [Key.cmd])


### PR DESCRIPTION
I really wanted to make it so that I can have a pause argument added automatically to all codeanim commands, like this:

```
jump(5, pause=0)
```

The problem is that my approach violates [PEP-612](https://peps.python.org/pep-0612/#id2) and so, even though the code works, there will never be valid type hints for it. Until a workaround appears, I don't want to have an interface that doesn't work with type hints. 

So an alternative is, we can make pause be the default behavior for delay (i.e., make it the first positional argument):

```
with delay(0):
    jump(5)
```