### PR TITLE
Improvements to the `tap` command and live presentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "codeanim"
-version = "0.0.6"
+version = "0.0.7"
 authors = [{ name = "Shad Sharma", email = "shadanan@gmail.com" }]
 description = "A tool to animate VS Code"
 dependencies = ["pynput", "pyperclip"]
-readme = "README"
+readme = "README.md"
 
 [project.scripts]
 codeanim = "codeanim:main"

--- a/src/codeanim/__init__.py
+++ b/src/codeanim/__init__.py
@@ -6,6 +6,7 @@ from . import chrome, core, markdown, vscode  # noqa: F401
 from .monitor import KeyMonitor
 
 # Public API
+Key = core.Key
 backspace = core.backspace
 delay = core.delay
 pause = core.delay.pause

--- a/src/codeanim/core.py
+++ b/src/codeanim/core.py
@@ -104,10 +104,11 @@ def codeanim(func: Callable[P, R]) -> Callable[P, R]:
     return codeanim_func
 
 
-def tap(key: str | Key, *, modifiers: list[str | Key] = []):
+def tap(key: str | Key, *, modifiers: list[str | Key] = [], repeat: int = 1):
     for modifier in modifiers:
         keyboard.press(modifier)
-    keyboard.tap(key)
+    for _ in range(repeat):
+        keyboard.tap(key)
     for modifier in modifiers:
         keyboard.release(modifier)
     time.sleep(delay.keys.get(key, delay.tap))

--- a/src/codeanim/markdown.py
+++ b/src/codeanim/markdown.py
@@ -13,10 +13,10 @@ def parse(path: str, labels: list[str] | None, live: bool) -> list[str]:
             codeanim = len(tokens) > 1 and tokens[1] == "codeanim"
             label = tokens[2] if len(tokens) > 2 else ""
             is_codeanim = codeanim and (labels is None or label in labels)
-            continue
-        if line == "```":
             if is_codeanim and live:
                 codeanim_lines.append("wait()")
+            continue
+        if line == "```":
             is_codeanim = False
             continue
         if is_codeanim:

--- a/src/codeanim/vscode.py
+++ b/src/codeanim/vscode.py
@@ -98,13 +98,13 @@ def focus(file: str):
 
 
 @core.codeanim
-def focus_terminal():
-    core.tap("`", modifiers=[Key.ctrl])
+def focus_editor():
+    core.tap("1", modifiers=[Key.ctrl])
 
 
 @core.codeanim
-def focus_editor():
-    core.tap("1", modifiers=[Key.ctrl])
+def toggle_terminal():
+    core.tap("`", modifiers=[Key.ctrl])
 
 
 @core.codeanim
@@ -119,7 +119,7 @@ def toggle_primary_sidebar():
 
 @core.codeanim
 def clear_terminal():
-    focus_terminal()
+    toggle_terminal()
     core.tap("k", modifiers=[Key.cmd])
     focus_editor()
 


### PR DESCRIPTION
- Expose `Key` in the public API so that they can be used with `tap`.
- Add a `repeat` argument to the `tap` command.
- Move the generated `wait()` to occur before CodeAnim code blocks instead of after.
- Rename `focus_terminal` -> `toggle_terminal`.
- Bump version.
