### PR TITLE
Add support for aborting execution and mouse scroll

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codeanim"
-version = "0.0.18"
+version = "0.0.19"
 description = "A tool that automates presentation of software demos."
 authors = ["Shad Sharma <shadanan@gmail.com>"]
 readme = "README.md"

--- a/src/codeanim/__init__.py
+++ b/src/codeanim/__init__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import os
+from functools import partial
 
 from pynput.keyboard import Key  # noqa: F401
 from pynput.mouse import Button  # noqa: F401
@@ -18,6 +19,7 @@ drag = codeanim.drag
 move = codeanim.move
 paste = codeanim.paste
 pause = codeanim.delay.pause
+scroll = codeanim.scroll
 tap = codeanim.tap
 wait = codeanim.wait
 write = codeanim.write
@@ -63,9 +65,16 @@ def main():
         action="store_true",
         help="Insert wait after each codeanim block",
     )
+    parser.add_argument(
+        "--abort-key",
+        default=Key.shift_r,
+        type=partial(getattr, Key),
+        help="Abort CodeAnim execution when this key is pressed",
+    )
     args = parser.parse_args()
 
     delay.set(end=args.end_delay, tap=args.tap_delay)
+    codeanim.keyboard.set_abort_key(args.abort_key)
 
     with codeanim:
         expressions = parse(

--- a/src/codeanim/core.py
+++ b/src/codeanim/core.py
@@ -26,6 +26,7 @@ class CodeAnim:
         self.drag = drag
         self.move = move
         self.paste = paste
+        self.scroll = scroll
         self.tap = tap
         self.wait = self.keyboard.wait
         self.write = write
@@ -51,6 +52,8 @@ class CodeAnim:
             *args: P.args,
             **kwargs: P.kwargs,
         ) -> R:
+            if codeanim.keyboard.aborted:
+                raise Exception("aborted")
             codeanim._call_stack.append(func.__name__)
             result = func(codeanim, *args, **kwargs)
             codeanim._call_stack.pop()
@@ -127,6 +130,11 @@ def paste(ca: CodeAnim, text: str, *, paste_delay: float = 0.5):
     pyperclip.copy(text)
     ca.tap("v", modifiers=[Key.cmd])
     time.sleep(paste_delay)  # Need to wait for the paste to finish
+
+
+@CodeAnim.cmd
+def scroll(ca: CodeAnim, dx: int, dy: int):
+    ca.mouse.scroll(dx, dy)
 
 
 @CodeAnim.cmd

--- a/src/codeanim/keyboard.py
+++ b/src/codeanim/keyboard.py
@@ -5,13 +5,22 @@ from pynput.keyboard import Controller, Key, KeyCode, Listener
 
 
 class Keyboard:
-    def __init__(self):
+    def __init__(self, abort_key: Key = Key.shift_r):
         self.controller = Controller()
         self.press = Event()
         self.released: Key | KeyCode | None = None
         self.listener: Listener | None = None
 
+        self.aborted = False
+        self.abort_key = abort_key
+
+    def set_abort_key(self, key: Key):
+        self.abort_key = key
+
     def handle_press(self, key: Key | KeyCode | None):
+        if key == self.abort_key:
+            self.aborted = True
+            print(f"Aborting because {key} was pressed...")
         pass
 
     def handle_release(self, key: Key | KeyCode | None):


### PR DESCRIPTION
To abort execution, the default key is the right shift. But it can be changed by passing --abort-key at the CLI. For example:

```shell
codeanim --abort-key=alt_r
```

Also added support for scrolling.