### PR TITLE
Support for one-off labels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "codeanim"
-version = "0.0.24"
+version = "0.0.25"
 description = "A tool that automates presentation of software demos."
 authors = ["Shad Sharma <shadanan@gmail.com>"]
 readme = "README.md"

--- a/src/codeanim/markdown.py
+++ b/src/codeanim/markdown.py
@@ -21,10 +21,11 @@ def parse(
             label = tokens[2] if len(tokens) > 2 else ""
             if label == start_label:
                 found_start_label = True
-            is_codeanim = (
-                codeanim
-                and (labels is None or label in labels)
-                and (start_label is None or found_start_label)
+            is_codeanim = codeanim and (
+                labels is None
+                or label in labels
+                or start_label is None
+                or found_start_label
             )
             if is_codeanim and live:
                 codeanim_lines.append("wait()")


### PR DESCRIPTION
Sometimes you want to start codeanim at a certain point in the script, but you also want to include a header. You can do that now:

```sh
codeanim "Python/If Statements with Turtle Graphics.md" -v --labels header --start-label grass-3
```

This will start codeanim at the `grass-3` label, but will also execute the `header` label, which contains some helper functions that all other cells depend on.